### PR TITLE
Move library projects from NETCoreApp to NETStandard and update C# language level to 7.2 - SERVER-64

### DIFF
--- a/CompilerPlugin/CompilerPlugin.csproj
+++ b/CompilerPlugin/CompilerPlugin.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>

--- a/CompilerPlugin/CompilerPlugin.csproj
+++ b/CompilerPlugin/CompilerPlugin.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ICompilerPlugin.DotNetCore/ICompilerPlugin.DotNetCore.csproj
+++ b/ICompilerPlugin.DotNetCore/ICompilerPlugin.DotNetCore.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ICompilerPlugin.DotNetCore/ICompilerPlugin.DotNetCore.csproj
+++ b/ICompilerPlugin.DotNetCore/ICompilerPlugin.DotNetCore.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>

--- a/ICompilerPlugin.Java/ICompilerPlugin.Java.csproj
+++ b/ICompilerPlugin.Java/ICompilerPlugin.Java.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ICompilerPlugin.Java/ICompilerPlugin.Java.csproj
+++ b/ICompilerPlugin.Java/ICompilerPlugin.Java.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>

--- a/ICompilerPlugin.ScriptLanguage/ICompilerPlugin.ScriptLanguage.csproj
+++ b/ICompilerPlugin.ScriptLanguage/ICompilerPlugin.ScriptLanguage.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ICompilerPlugin.ScriptLanguage/ICompilerPlugin.ScriptLanguage.csproj
+++ b/ICompilerPlugin.ScriptLanguage/ICompilerPlugin.ScriptLanguage.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>

--- a/ICompilerPlugin.TypicalCompiler/ICompilerPlugin.TypicalCompiler.csproj
+++ b/ICompilerPlugin.TypicalCompiler/ICompilerPlugin.TypicalCompiler.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ICompilerPlugin.TypicalCompiler/ICompilerPlugin.TypicalCompiler.csproj
+++ b/ICompilerPlugin.TypicalCompiler/ICompilerPlugin.TypicalCompiler.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <RootNamespace>CompilerPlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>

--- a/IJudgePlugin.Full/IJudgePlugin.Full.csproj
+++ b/IJudgePlugin.Full/IJudgePlugin.Full.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>JudgePlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/IJudgePlugin.None/IJudgePlugin.None.csproj
+++ b/IJudgePlugin.None/IJudgePlugin.None.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>JudgePlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/IJudgePlugin.TestByTest/IJudgePlugin.TestByTest.csproj
+++ b/IJudgePlugin.TestByTest/IJudgePlugin.TestByTest.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>JudgePlugin</RootNamespace>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/JudgePlugin/JudgePlugin.csproj
+++ b/JudgePlugin/JudgePlugin.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/Plugin/Plugin.csproj
+++ b/Plugin/Plugin.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ReleaseTestInfo/ReleaseTestInfo.csproj
+++ b/ReleaseTestInfo/ReleaseTestInfo.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ServerExceptions/ServerExceptions.csproj
+++ b/ServerExceptions/ServerExceptions.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/ServerPlugin/ServerPlugin.csproj
+++ b/ServerPlugin/ServerPlugin.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>../Build/</OutputPath>

--- a/SubmissionInfo/SubmissionInfo.csproj
+++ b/SubmissionInfo/SubmissionInfo.csproj
@@ -4,6 +4,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <Configurations>Release;Debug</Configurations>
     <Platforms>x64</Platforms>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <DebugType>none</DebugType>


### PR DESCRIPTION
## Summary
Move library projects from NETCoreApp to NETStandard and update C# language level to `7.2` as part of **SERVER-64**.

## Relates to
<A list of unique issue identificators and links to them>

- **SERVER-64** https://simplepm.atlassian.net/projects/SERVER/issues/SERVER-64
